### PR TITLE
Fix missing @ decorator on sky_area abstractproperty

### DIFF
--- a/tdaspop/population_params_absracts.py
+++ b/tdaspop/population_params_absracts.py
@@ -139,10 +139,10 @@ class BaseRateDistributions(with_metaclass(abc.ABCMeta, object)):
         """
         pass
 
-    abc.abstractproperty
-
+    @abc.abstractproperty
     def sky_area(self):
         """ The area of the sky in sq degrees over which the sample is studies"""
+        pass
 
     @abc.abstractproperty
     def z_sample_sizes(self):


### PR DESCRIPTION
## Summary
- `sky_area` in `BaseRateDistributions` was declared as a bare `abc.abstractproperty` expression statement (missing the `@`), followed by a plain method with no body. It was therefore never enforced as abstract and returned `None` if ever called directly.
- Adds the missing `@` decorator and a `pass` body, matching the style of every other `abstractproperty` in the class.

## Test plan
- [x] `python -m pytest tests/` — same pass/fail result as on `master` (1 pre-existing, unrelated failure in `test_ratedistribution.py::test_limiting_case_easy` due to an astropy API change, confirmed present on `master` too)
- [x] Verified `PowerLawRates`, the only concrete subclass, already implements `sky_area` as a `@property`, so instantiation is unaffected

Fixes #42