### PR TITLE
Add bump-my-version for automatic version bumping

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,11 @@
+[tool.bumpversion]
+current_version = "0.2.0"
+commit = true
+tag = true
+tag_name = "v{new_version}"
+message = "Bump version: {current_version} -> {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "tdaspop/version.py"
+search = '__VERSION__ = "{current_version}"'
+replace = '__VERSION__ = "{new_version}"'

--- a/README.md
+++ b/README.md
@@ -20,4 +20,12 @@ A very simple example based on a a light curve being sinosoidal, devoid of astro
 
 A couple of implementations of more realistic, astrophysical distributions are shown Supernovae Type Ia, modeled using the well known SALT model are setup in the [SNPop](https://github.com/rbiswas4/SNPop) repository. These population models `SimpleSALTPopulation` and `GMM_SALTPopulation`, coded up within the `snpop` package inherit from `varpop` populations and the code can be seen in a package [module](https://github.com/rbiswas4/SNPop/blob/master/snpop/saltpop.py), and their basic functionality is demonstrated as JuPyteR notebooks [here](https://github.com/rbiswas4/SNPop/blob/master/Examples/Demo_Gmm.ipynb) and [here](https://github.com/rbiswas4/SNPop/blob/master/Examples/Demo_SimpleSALTPopulation.ipynb). 
 
+## Releasing
+
+Versioning is managed with [bump-my-version](https://github.com/callowayproject/bump-my-version) (`pip install bump-my-version`, or already included in `install/pip-requirements.txt`). To cut a release, bump `tdaspop/version.py` and tag the commit with one command:
+```
+bump-my-version bump patch   # or minor / major
+```
+This updates `tdaspop/version.py`, commits the change, and creates a matching `vX.Y.Z` git tag.
+
 

--- a/install/pip-requirements.txt
+++ b/install/pip-requirements.txt
@@ -6,3 +6,4 @@ pytest-cov
 python-coveralls
 coverage
 matplotlib
+bump-my-version


### PR DESCRIPTION
## Summary
- Adds `.bumpversion.toml`, configuring [bump-my-version](https://github.com/callowayproject/bump-my-version) to bump `__VERSION__` in `tdaspop/version.py` and create a matching `vX.Y.Z` tag + commit — replaces manually editing `version.py` by hand on every release.
- Adds `bump-my-version` to `install/pip-requirements.txt` (this repo's existing dev-tooling list, alongside pytest/coverage).
- Documents the release command in a new README "Releasing" section.

## Test plan
- [x] `bump-my-version bump patch --dry-run --verbose` — correctly detects current version `0.2.0`, proposes `0.2.1`, and shows the intended edit to `tdaspop/version.py`
- [x] `python -m pytest tests/` — same result as `master` (1 pre-existing, unrelated failure in `test_limiting_case_easy` from an astropy API change)

Fixes #44