### PR TITLE
Add GMMSampler to sample Gaussian Mixture Models

### DIFF
--- a/install/pip-requirements.txt
+++ b/install/pip-requirements.txt
@@ -1,5 +1,6 @@
 numpy
 scipy
+scikit-learn
 pytest
 future
 pytest-cov

--- a/tdaspop/sampling.py
+++ b/tdaspop/sampling.py
@@ -1,9 +1,10 @@
 """
 Sampling routines
 """
-__all__ = ['Sample1D']
+__all__ = ['Sample1D', 'GMMSampler']
 
 import numpy as np
+from sklearn.mixture import GaussianMixture
 
 
 class Sample1D(object):
@@ -69,3 +70,56 @@ class Sample1D(object):
         cdf_sample = rng.uniform(size=size)
         vals = self.x_from_cdf(cdf_sample)
         return vals
+
+
+class GMMSampler(object):
+    """
+    Class to draw samples from a Gaussian Mixture Model (GMM) with known
+    component weights, means and covariances, using
+    `sklearn.mixture.GaussianMixture`.
+
+    Parameters
+    ----------
+    weights : `np.ndarray`, shape (n_components,)
+        mixture weight of each component. Must sum to 1.
+    means : `np.ndarray`, shape (n_components, n_features)
+        mean of each Gaussian component.
+    covariances : `np.ndarray`, shape (n_components, n_features, n_features)
+        covariance matrix of each Gaussian component.
+    """
+    def __init__(self, weights, means, covariances):
+        self.weights = np.asarray(weights)
+        self.means = np.asarray(means)
+        self.covariances = np.asarray(covariances)
+
+        n_components = self.means.shape[0]
+        self._gmm = GaussianMixture(n_components=n_components,
+                                     covariance_type='full')
+        # Set the mixture parameters directly instead of calling `fit`,
+        # since the GMM here is already fully specified.
+        self._gmm.weights_ = self.weights
+        self._gmm.means_ = self.means
+        self._gmm.covariances_ = self.covariances
+
+    def sample(self, size=1, rng=None):
+        """
+        Draw samples from the GMM.
+
+        Parameters
+        ----------
+        size : int, defaults to 1
+            number of samples requested
+        rng : int or `np.random.RandomState` instance, defaults to `None`
+            random state used for reproducibility. If `None`, the samples
+            are not reproducible between calls.
+
+        Returns
+        -------
+        X : `np.ndarray`, shape (size, n_features)
+            samples drawn from the GMM
+        component : `np.ndarray`, shape (size,)
+            index of the mixture component each sample was drawn from
+        """
+        self._gmm.random_state = rng
+        X, component = self._gmm.sample(size)
+        return X, component

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -6,7 +6,7 @@ from scipy.stats import norm
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-from tdaspop import Sample1D
+from tdaspop import Sample1D, GMMSampler
 
 def test_running_dg():
     rng = np.random.RandomState(1)
@@ -31,3 +31,31 @@ def test_default_rng_reproducible():
     r1 = s1d.sample_pdf(size=100)
     r2 = s1d.sample_pdf(size=100)
     np.testing.assert_array_equal(r1, r2)
+
+
+def test_gmm_sampler():
+    weights = np.array([0.3, 0.7])
+    means = np.array([[0., 0.], [10., 10.]])
+    covariances = np.array([np.eye(2), np.eye(2) * 4.])
+
+    gmm = GMMSampler(weights, means, covariances)
+    X, component = gmm.sample(size=100000, rng=np.random.RandomState(1))
+
+    assert X.shape == (100000, 2)
+    assert component.shape == (100000,)
+
+    # Component fractions should match the input weights
+    frac0 = np.mean(component == 0)
+    np.testing.assert_allclose(frac0, weights[0], atol=0.01)
+
+    # Per component means and stds should match the input parameters
+    np.testing.assert_allclose(X[component == 0].mean(axis=0), means[0], atol=0.05)
+    np.testing.assert_allclose(X[component == 1].mean(axis=0), means[1], atol=0.1)
+    np.testing.assert_allclose(X[component == 0].std(axis=0), 1., atol=0.05)
+    np.testing.assert_allclose(X[component == 1].std(axis=0), 2., atol=0.05)
+
+    # Reproducibility with the same rng seed
+    X2, component2 = gmm.sample(size=100, rng=np.random.RandomState(42))
+    X3, component3 = gmm.sample(size=100, rng=np.random.RandomState(42))
+    np.testing.assert_array_equal(X2, X3)
+    np.testing.assert_array_equal(component2, component3)


### PR DESCRIPTION
## Summary
- Adds `GMMSampler` (`tdaspop/sampling.py`), a thin wrapper around `sklearn.mixture.GaussianMixture` for drawing samples from a GMM with known component `weights`, `means`, and `covariances`. The mixture parameters are set directly on the estimator (no `.fit()` call, since the GMM is already fully specified) and `sample(size, rng)` draws `(X, component)` pairs.
- `rng` is passed per-call (not baked into the constructor) to avoid the mutable-default-RandomState pitfall already present elsewhere in this codebase (`double_gaussian`, `Sample1D.sample_pdf`) -- passing the same seed twice reproduces the same draw.
- Adds `scikit-learn` to `install/pip-requirements.txt`, and a test (`tests/test_sampling.py::test_gmm_sampler`) checking output shape, per-component weight/mean/std recovery, and reproducibility.

Descoped from the issue's original "extreme deconvolution" framing (fitting a GMM to noisy data) down to just sampling from an already-specified GMM, per discussion on #34.

## Test plan
- [x] `python -m pytest tests/test_sampling.py` -- both tests pass
- [x] `python -m pytest tests/` -- same result as `master` (1 pre-existing, unrelated failure in `test_limiting_case_easy` from an astropy API change)
- [x] Manually verified `GaussianMixture.sample()` works with parameters set directly (no private sklearn API needed)

Fixes #34