### PR TITLE
Fix double gaussian RandomState, logpdf typo, and scalar support

### DIFF
--- a/tdaspop/pop_dists.py
+++ b/tdaspop/pop_dists.py
@@ -8,7 +8,7 @@ from scipy.stats import norm
 
 
 def double_gaussian(mode, sigmam, sigmap, size=1000,
-                    rng=np.random.RandomState(1)):
+                    rng=None):
     """Draw samples from a double gaussian distribution
 
 
@@ -22,7 +22,8 @@ def double_gaussian(mode, sigmam, sigmap, size=1000,
 	standard deviation of the distribution
     size: int
 	number of samples required
-    rng: instance `np.random.RandomState`, defaults to state with seed 1.
+    rng: instance `np.random.RandomState`, defaults to `None`
+	if `None`, a new `np.random.RandomState` with seed 1 is used.
 
     Returns
     -------
@@ -33,6 +34,9 @@ def double_gaussian(mode, sigmam, sigmap, size=1000,
     -----
     This code is essentially the same as code contributed by D. Rubin for SN.
     """
+    if rng is None:
+        rng = np.random.RandomState(1)
+
     # Stick to a convention sigmam is a +ve number
     sigs = np.abs([sigmam, sigmap])
     probs = sigs/sigs.sum()
@@ -46,7 +50,7 @@ def double_gaussian_pdf(x, mode, sigmam, sigmap):
 
     Parameters
     ----------
-    x : `np.ndarray` of floats 
+    x : scalar or `np.ndarray` of floats
     mode : float
         mode of the distribution
     sigmam : float
@@ -54,15 +58,19 @@ def double_gaussian_pdf(x, mode, sigmam, sigmap):
     sigmap : float
         standard deviation of higher side
     """
+    x = np.asarray(x, dtype=float)
+    scalar_input = x.ndim == 0
+    x = np.atleast_1d(x)
+
     A = 2.0 / (sigmam + sigmap)
 
     mask = x > mode
 
-    pdf = sigmam * norm.pdf(x, mode, sigmam) 
-    pdf[mask] = sigmap * norm.pdf(x[mask], mode, sigmap) 
+    pdf = sigmam * norm.pdf(x, mode, sigmam)
+    pdf[mask] = sigmap * norm.pdf(x[mask], mode, sigmap)
     pdf *= A
 
-    return pdf
+    return pdf[0] if scalar_input else pdf
 
 def double_gaussian_logpdf(x, mode, sigmam, sigmap):
     """
@@ -70,7 +78,7 @@ def double_gaussian_logpdf(x, mode, sigmam, sigmap):
 
     Parameters
     ----------
-    x : `np.ndarray` of floats 
+    x : scalar or `np.ndarray` of floats
     mode : float
         mode of the distribution
     sigmam : float
@@ -78,13 +86,17 @@ def double_gaussian_logpdf(x, mode, sigmam, sigmap):
     sigmap : float
         standard deviation of higher side
     """
+    x = np.asarray(x, dtype=float)
+    scalar_input = x.ndim == 0
+    x = np.atleast_1d(x)
+
     A = 2.0 / (sigmam + sigmap)
     logA = np.log(A)
 
     mask = x > mode
 
-    logpdf = np.log(sigmam) +   norm.logpdf(x, mode, sigmam) 
-    logpdf[mask] = np.log(sigmap) +   norm.logpdf(x[mask], mode, sigmap) 
-    logpdf += A
+    logpdf = np.log(sigmam) +   norm.logpdf(x, mode, sigmam)
+    logpdf[mask] = np.log(sigmap) +   norm.logpdf(x[mask], mode, sigmap)
+    logpdf += logA
 
-    return logpdf
+    return logpdf[0] if scalar_input else logpdf

--- a/tdaspop/sampling.py
+++ b/tdaspop/sampling.py
@@ -48,14 +48,14 @@ class Sample1D(object):
         """
         return np.interp(cdf, self.cdf, self.xvals)
 
-    def sample_pdf(self, rng=np.random.RandomState(0), size=100):
+    def sample_pdf(self, rng=None, size=100):
         """
         Samples drawn from the pdf  with a random state of requested size
 
         Parameters
         ----------
-        rng : `np.random.RandomState` instance, defaults to `RandomState(0)`
-            random state 
+        rng : `np.random.RandomState` instance, defaults to `None`
+            if `None`, a new `np.random.RandomState` with seed 0 is used.
         size : int, defaults to 100
             number of samples requested
 
@@ -64,6 +64,8 @@ class Sample1D(object):
         vals : `np.ndarray`
             numpy array containing samples
         """
+        if rng is None:
+            rng = np.random.RandomState(0)
         cdf_sample = rng.uniform(size=size)
         vals = self.x_from_cdf(cdf_sample)
         return vals

--- a/tests/test_pop_dists.py
+++ b/tests/test_pop_dists.py
@@ -39,10 +39,30 @@ def test_double_gaussian_logpdf():
     num_points = 2 * 1000000
     min_val = -1000. 
     max_val = 1000
-    x = np.linspace(min_val, max_val, num_points) 
+    x = np.linspace(min_val, max_val, num_points)
     pdf = double_gaussian_pdf(x, mode=mode, sigmam=sigmam, sigmap=sigmap)
     logpdf = double_gaussian_logpdf(x, mode=mode, sigmam=sigmam, sigmap=sigmap)
-    np.testing.assert_allclose(pdf, np.exp(logpdf), rtol=5)
+    np.testing.assert_allclose(pdf, np.exp(logpdf), rtol=1e-6, atol=1e-300)
+
+def test_double_gaussian_scalar_input():
+
+    mode = 20.
+    sigmam = 1.
+    sigmap = 8.
+
+    for x in (19.5, 20.5):
+        pdf = double_gaussian_pdf(x, mode=mode, sigmam=sigmam, sigmap=sigmap)
+        logpdf = double_gaussian_logpdf(x, mode=mode, sigmam=sigmam, sigmap=sigmap)
+        assert np.isscalar(pdf) or pdf.ndim == 0
+        np.testing.assert_allclose(pdf, np.exp(logpdf), rtol=1e-6)
+
+def test_double_gaussian_default_rng_reproducible():
+    # Repeated calls without an explicit `rng` should be reproducible,
+    # each drawing from a fresh `RandomState(1)` rather than sharing state
+    # across calls.
+    samps1 = double_gaussian(1., 1., 2., size=100)
+    samps2 = double_gaussian(1., 1., 2., size=100)
+    np.testing.assert_array_equal(samps1, samps2)
 
 def test_double_gaussian_pdf_integral():
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -20,3 +20,14 @@ def test_running_dg():
                                     histtype='stepfilled', density=True)
     xv = 0.5 * (bins[0:-1] + bins[1:])
     assert max(counts - norm.cdf(xv)) < 0.02
+
+def test_default_rng_reproducible():
+    # Repeated calls without an explicit `rng` should be reproducible,
+    # each drawing from a fresh `RandomState(0)` rather than sharing state
+    # across calls.
+    xx = np.linspace(-5., 5., 10000)
+    pd = norm.pdf(xx)
+    s1d = Sample1D(xx, pd)
+    r1 = s1d.sample_pdf(size=100)
+    r2 = s1d.sample_pdf(size=100)
+    np.testing.assert_array_equal(r1, r2)


### PR DESCRIPTION
## Summary
All three items from #47:
- **RandomState**: `double_gaussian` and `Sample1D.sample_pdf` used `rng=np.random.RandomState(seed)` as a default argument -- evaluated once at import time, so it silently accumulates state across every call that omits `rng`, breaking the "defaults to seed N" reproducibility promised in the docstrings. Both now default to `rng=None` and build a fresh `RandomState` internally per call.
- **logpdf typo**: `double_gaussian_logpdf` added the linear-space normalization constant `A` instead of `logA` (both were computed, only `logA` was ever meant to be used). This made `exp(logpdf)` diverge from `pdf` by a constant factor (~5.6x for sigmam=1, sigmap=8). The existing regression test used `rtol=5` (500% tolerance), loose enough to miss this -- tightened to `rtol=1e-6` so it actually verifies the fix.
- **Scalar/vector support**: `double_gaussian_pdf`/`double_gaussian_logpdf` indexed into `pdf`/`logpdf` with a boolean mask, which raised `TypeError` on scalar `x` (numpy scalars aren't subscriptable). Both now accept a scalar, list, or ndarray and return a matching type.

## Test plan
- [x] `python -m pytest tests/test_pop_dists.py tests/test_sampling.py -v` -- all 8 pass, including 3 new tests (scalar input, logpdf/pdf consistency at tight tolerance, RNG reproducibility x2)
- [x] `python -m pytest tests/` -- same result as `master` (1 pre-existing, unrelated failure in `test_limiting_case_easy` from an astropy API change)
- [x] Manually verified `exp(logpdf)` now matches `pdf` to ~1e-13 relative precision (previously off by ~5.6x)

Fixes #47