### PR TITLE
Fix test call to comoving_volume for newer astropy

### DIFF
--- a/tests/test_ratedistribution.py
+++ b/tests/test_ratedistribution.py
@@ -54,5 +54,5 @@ def test_limiting_case_easy():
                        cosmo=cosmo,
                        beta_rate=1.0)
 
-    vol =  cosmo.comoving_volume(z=1.2).value
+    vol =  cosmo.comoving_volume(1.2).value
     np.testing.assert_allclose(vol * 3.0e-5 * (cosmo.h/0.7)**3, pl.z_sample_sizes.sum(), rtol=0.001) 


### PR DESCRIPTION
## Summary
- `tests/test_ratedistribution.py:57` called `cosmo.comoving_volume(z=1.2)`. In recent astropy (verified against 8.0.1), `FLRW.comoving_volume(z, /)` marks `z` positional-only, so the keyword call raised `TypeError: FLRW.comoving_volume() got some positional-only arguments passed as keyword arguments: 'z'`.
- Passes `1.2` positionally instead. This is test-only; the library code (`PowerLawRates.volume_in_zshell` in `rateDistributions.py`) already calls `cosmo.comoving_volume(zbin_edges)` positionally and was unaffected.

## Test plan
- [x] `python -m pytest tests/test_ratedistribution.py -v` -- all 3 pass (previously 1 failure)
- [x] `python -m pytest tests/` -- full suite passes, no failures

Fixes #49