### PR TITLE
Set up Sphinx autodoc and Read the Docs config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: docs
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -r docs/requirements.txt
+          pip install -e .
+
+      - name: Build docs
+        run: sphinx-build -b html -W docs docs/_build/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ bump-my-version bump patch   # or minor / major
 ```
 This updates `tdaspop/version.py`, commits the change, and creates a matching `vX.Y.Z` git tag.
 
+## Documentation
+
+API docs are built with [Sphinx](https://www.sphinx-doc.org/) from the docstrings in `tdaspop/` (numpy-style, parsed via `sphinx.ext.napoleon`), configured for [Read the Docs](https://readthedocs.org/) via `.readthedocs.yaml`. To build locally:
+```
+pip install -r docs/requirements.txt
+pip install -e .
+sphinx-build -b html docs docs/_build/html
+```
+then open `docs/_build/html/index.html`. A `docs` GitHub Actions workflow builds the docs (with warnings treated as errors) on every push and PR as a sanity check.
+
+To actually host these on readthedocs.org, the repo needs to be imported there once (Import a Project -> select `rbiswas4/TdasPop`) by an account owner -- that step can't be done from here.
+
 ## Code style
 
 Code is formatted with [Black](https://github.com/psf/black), enforced via [pre-commit](https://pre-commit.com/) (`pip install pre-commit`, or already included in `install/pip-requirements.txt`). To enable it locally, run once per clone:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,34 @@
+API Reference
+=============
+
+Population and rate distribution abstractions
+-----------------------------------------------
+
+.. automodule:: tdaspop.population_params_absracts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Rate distributions
+-------------------
+
+.. automodule:: tdaspop.rateDistributions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Population distributions
+--------------------------
+
+.. automodule:: tdaspop.pop_dists
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Sampling
+---------
+
+.. automodule:: tdaspop.sampling
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+from tdaspop.version import __VERSION__
+
+project = 'TdasPop'
+copyright = '2026, R. Biswas'
+author = 'R. Biswas'
+version = __VERSION__
+release = __VERSION__
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
+]
+
+# Napoleon settings: this codebase uses numpy-style docstrings
+# (Parameters/Returns sections), not Google-style.
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': True,
+}
+autodoc_mock_imports = []
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'sklearn': ('https://scikit-learn.org/stable/', None),
+}
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'sphinx_rtd_theme'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,35 @@
+TdasPop
+=======
+
+A base repository to provide common infrastructure in describing populations
+of Time Domain Astronomy Sources (astrophysical objects with luminosities
+varying over time scales to be detected as changing by LSST) of different
+classes, sampling those populations and validating the distributions.
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install tdaspop
+
+or from source:
+
+.. code-block:: bash
+
+   git clone https://github.com/rbiswas4/TdasPop.git
+   cd TdasPop
+   pip install -e .
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   api
+
+Indices and tables
+-------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+sphinx
+sphinx-rtd-theme
+numpy
+scipy
+astropy
+scikit-learn
+future

--- a/tdaspop/population_params_absracts.py
+++ b/tdaspop/population_params_absracts.py
@@ -19,13 +19,7 @@ class BasePopulation(with_metaclass(abc.ABCMeta, object)):
     population is specified by a unique index idx. The model parameters for an
     object (ie. index) is obtained as a dictionary using the method modelparams.
 
-    
-    Attributes
-    ----------
-    paramsTable : `pd.DataFrame`
-        a dataframe with parameters of the model index by a set of index values.
-
-    .. note : this is a general enough class to deal with any population. 
+    .. note:: this is a general enough class to deal with any population.
     """
 
     @abc.abstractproperty
@@ -38,6 +32,10 @@ class BasePopulation(with_metaclass(abc.ABCMeta, object)):
 
     @abc.abstractproperty
     def paramsTable(self):
+        """
+        `pd.DataFrame` with parameters of the model indexed by a set of
+        index values.
+        """
         pass
 
     def modelParams(self, idx):


### PR DESCRIPTION
## Summary
Issue #9 asked to get docs set up, likely with readthedocs. This wires up Sphinx autodoc against the existing numpy-style docstrings and a Read the Docs config:

- `docs/conf.py`, `docs/index.rst`, `docs/api.rst` -- `sphinx.ext.autodoc` + `sphinx.ext.napoleon` (numpy docstring style, matching what's already used throughout `tdaspop/`), pulling in all four modules (`population_params_absracts`, `rateDistributions`, `pop_dists`, `sampling`) via `automodule`/`:members:`.
- `docs/requirements.txt` -- sphinx, sphinx-rtd-theme, plus the package's own runtime deps (numpy/scipy/astropy/scikit-learn/future), since autodoc has to actually import `tdaspop` to introspect docstrings and `setup.py` doesn't declare `install_requires`.
- `.readthedocs.yaml` (v2 schema) pointing at `docs/conf.py`, installing `docs/requirements.txt` plus the package itself.
- `.github/workflows/docs.yml` -- builds the docs with `-W` (warnings-as-errors) on every push/PR, so a docstring regression fails CI instead of silently breaking the docs.
- README "Documentation" section with local build instructions.

**One manual step left for you**: hosting on readthedocs.org requires importing the repo there once (Import a Project -> `rbiswas4/TdasPop`) with an account that owns/administers the repo -- I can't do that from here. Everything else (build config, CI check) is ready for whenever that happens.

### Also fixed
While building the docs, autodoc/napoleon threw `WARNING: duplicate object description of ...BasePopulation.paramsTable`. Root cause: `BasePopulation`'s class docstring documented `paramsTable` in a numpydoc `Attributes` section, while the real `paramsTable` abstractproperty in the class body had no docstring of its own -- napoleon turned the `Attributes` entry into a real `py:attribute` directive that collided with the actual property. Moved the description onto the property itself (matching how every other abstractproperty in that class documents itself) and fixed a malformed `.. note :` line (missing `::`) that was being misparsed as a bogus attribute rather than rendering as an admonition. Docstring-only change, verified with the full test suite.

## Test plan
- [x] `sphinx-build -b html docs docs/_build/html` -- builds clean, 0 warnings (was 1 before the docstring fix)
- [x] `sphinx-build -b html -W docs docs/_build/html` -- passes (matches the CI workflow exactly)
- [x] `pytest tests/` -- all 12 pass, confirming the docstring edit didn't change behavior
- [x] Real GitHub Actions runs against this PR: both `docs` and `tests` workflows pass

Fixes #9