### PR TITLE
Update CI trigger and badge for master -> main rename

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Time Domain Astronomy Sources Populations
 
-[![tests](https://github.com/rbiswas4/TdasPop/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/rbiswas4/TdasPop/actions/workflows/tests.yml)[![PyPI version](https://badge.fury.io/py/tdaspop.svg)](https://badge.fury.io/py/tdaspop)
+[![tests](https://github.com/rbiswas4/TdasPop/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/rbiswas4/TdasPop/actions/workflows/tests.yml)[![PyPI version](https://badge.fury.io/py/tdaspop.svg)](https://badge.fury.io/py/tdaspop)
 
 A base repository to provide common infrastructure in describing populations of Time Domain Astronomy Sources (astrophysical objects with luminosities varying over time scales to be detected as changing by LSST) of different classes, sampling those populations and validating the distributions.
 


### PR DESCRIPTION
## Summary
The repo's default branch is now `main` (renamed from `master` via the GitHub `branches/rename` API, which also automatically retargeted the one open PR at the time, #53). This fixes the leftover hardcoded references:

- `.github/workflows/tests.yml`: push trigger `branches: [master]` -> `[main]`
- `README.md`: tests badge URL `?branch=master` -> `?branch=main`

Left alone: the `master` references in the README pointing at `github.com/rbiswas4/SNPop/blob/master/...` -- that's a different repository I don't control, not this one.

## Test plan
- [x] `pytest tests/` -- all 12 pass
- [x] `grep -rln master` across the repo (excluding `.git`) -- only the unrelated SNPop links remain

Fixes #54